### PR TITLE
Switch root to btrfs

### DIFF
--- a/fedora-phosh.mpp.json
+++ b/fedora-phosh.mpp.json
@@ -168,7 +168,7 @@
             "filesystems": [
               {
                 "uuid": {"mpp-format-string": "{rootfs_uuid}"},
-                "vfs_type": "xfs",
+                "vfs_type": "btrfs",
                 "path": "/",
                 "freq": 1,
                 "passno": 1
@@ -274,7 +274,7 @@
           }
         },
         {
-          "type": "org.osbuild.mkfs.xfs",
+          "type": "org.osbuild.mkfs.btrfs",
           "devices": {
             "device": {
               "type": "org.osbuild.loopback",
@@ -338,7 +338,7 @@
           "mounts": [
             {
               "name": "root",
-              "type": "org.osbuild.xfs",
+              "type": "org.osbuild.btrfs",
               "source": "root",
               "target": "/"
             },


### PR DESCRIPTION
On Fedora desktop the default file system is btrfs https://fedoraproject.org/wiki/Btrfs

Switching to btrfs on the mobility images also enables the benefits of btrfs for mobile. (Live resize being the one I am most happy about)
Outlined features in this fedora magazine article https://fedoramagazine.org/btrfs-coming-to-fedora-33/